### PR TITLE
fix "upload" in tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,7 +7,7 @@ cd sage-ecr
 ./run.sh -d
 ```
 
-## Define ECR_API and SAGE_USER_TOKEN variables
+## Define ECR_API, SAGE_USER_TOKEN variables
 ```bash
 export ECR_API="localhost:5000"
 export SAGE_USER_TOKEN="token1"
@@ -15,16 +15,14 @@ export SAGE_USER_TOKEN="token1"
 
 Optional: Use `jq` for pretty formatting of json output. [jq installation instructions](https://stedolan.github.io/jq/download/)
 
-## upload "simple plugin"
+## upload "simple plugin" under the namespace "sage"
 ```bash
-curl -X POST ${ECR_API}/submit -H "Authorization: sage ${SAGE_USER_TOKEN}" --data-binary  @./example_app.yaml | jq .
-
-# Note: repeating this call will re-upload the app, as long as the field "frozen" is false
-
-
-# save the app id you got from the previous call:
-export APP_ID=<...>
+curl -X POST ${ECR_API}/apps/sage/simple/1.0 -H "Authorization: sage ${SAGE_USER_TOKEN}" --data-binary  @./example_app.yaml | jq .
 ```
+
+Note: repeating this call will re-upload the app, as long as the field "frozen" is false
+
+
 ## get app
 ```bash
 curl -X GET  ${ECR_API}/apps/sage/simple/1.0 -H "Authorization: sage ${SAGE_USER_TOKEN}" | jq .


### PR DESCRIPTION
Fixing the upload example to provide the `namespace`, `name`, and `version` since they are commented out in the `example_app.yaml`.